### PR TITLE
Update ceilometerclient/v1/meters.py

### DIFF
--- a/ceilometerclient/v1/meters.py
+++ b/ceilometerclient/v1/meters.py
@@ -52,11 +52,15 @@ class ProjectManager(base.Manager):
 
     def list(self, **kwargs):
         s = kwargs.get('source')
+        opts = kwargs.get('metaquery')        
         if s:
             path = '/sources/%s/projects' % (kwargs['source'])
         else:
             path = '/projects'
-
+        if opts:
+            path = '/v1%s?%s' % (path, '&'.join(opts.split(':')))
+        else:
+            path = '/v1%s' % (path)
         return self._list('/v1/%s' % path, 'projects')
 
 


### PR DESCRIPTION
we are missing the /v1 path of the uri and the optional extra parameters are not accounted for.
